### PR TITLE
Add attribute to disable non-chef resolv.conf updates

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -80,3 +80,12 @@ suites:
   - name: default
     run_list:
       - recipe[resolver::default]
+    attributes: { "resolver": { "nameservers": ["8.8.8.8"]}}
+  - name: force_unlink
+    run_list:
+      - recipe[resolver::default]
+    attributes: { "resolver": {
+            "deactivate_resolvconf": true,
+            "nameservers": ["8.8.8.8"]}}
+    includes:
+      - ubuntu-14.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,3 +22,10 @@ suites:
   - name: default
     run_list:
       - recipe[resolver::default]
+    attributes: { "resolver": { "nameservers": ["8.8.8.8"]}}
+  - name: force_unlink
+    run_list:
+      - recipe[resolver::default]
+    attributes: { "resolver": {
+            "deactivate_resolvconf": true,
+            "nameservers": ["8.8.8.8"]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
   - INSTANCE=default-fedora-latest
   - INSTANCE=default-opensuse-leap
   - INSTANCE=default-ubuntu-1404
+  - INSTANCE=force-unlink-ubuntu-1404
   - INSTANCE=default-ubuntu-1604
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See `attributes/default.rb` for default values.
 - `node['resolver']['nameservers']` - Required, an array of nameserver IP address strings; the default is an empty array, and the default recipe will not change resolv.conf if this is not set. See **Usage**.
 - `node['resolver']['options']` - a hash of resolv.conf options. See **Usage** for examples.
 - `node['resolver']['domain']` - Local domain name. if `nil`, the domain is determined from the local hostname returned by `gethostname(2)`.
+- `node['resolver']['deactivate_resolveconf'] - Disable resolveconf management of `/etc/resolv.conf` by unlinking it. Useful on Ubuntu system so change managedment is rebootable. Default `false`.
 
 ## Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,3 +20,4 @@ default['resolver']['search'] = node['domain']
 default['resolver']['domain'] = nil
 default['resolver']['nameservers'] = []
 default['resolver']['options'] = {}
+default['resolver']['deactivate_resolvconf'] = false

--- a/test/integration/force_unlink/deactivate_resolvconf.rb
+++ b/test/integration/force_unlink/deactivate_resolvconf.rb
@@ -1,0 +1,4 @@
+describe file('/etc/resolv.conf') do
+  it { should be_file }
+  it { should_not be_symlink }
+end


### PR DESCRIPTION
### Description

Ubuntu (and maybe other distros as well) installs resolvconf by default in its non-Desktop base configuration. In this case, /etc/resolv.conf is a symlink to a file that resolvconf generates in /run (a tmpfs filesystem). resolvconf gets triggered by either network interfaces coming up or by DHCP clients (usually during bootup). Currently, this cookbook just overwrites the generated resolvconf file, but it leaves the potential for resolv.conf to become incorrect:
 * The DHCP server may not include all of the settings in the Chef template
 * DHCP lease renewals or interface state changes could cause resolvconf to regenerate the file, causing it to be incorrect until the next Chef run (if it doesn't break the configuration more seriously)

To avoid these issues, this cookbook should disable resolvconf (there is already a separate cookbook for resolvconf) by replacing the symbolic link with a regular file:

>  To make the resolver use this dynamically generated resolver configuration file the administrator should ensure that /etc/resolv.conf is a symbolic link to /run/resolvconf/resolv.conf. This link is normally created on installation of the resolvconf package. **The link is never modified by the resolvconf program itself.**

Source: http://manpages.ubuntu.com/manpages/zesty/man8/resolvconf.8.html#contenttoc4

This PR allows adds an attribute to support this behavior, but conservatively avoids changing the default behavior (in the hopes of making this easier to merge). I think that this attribute flag should subsequently be flipped to true for Ubuntu with a major version bump.

### Issues Resolved
#20
#31 
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
