### PR TITLE
Merge resolv.conf options & remove extra colons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the resolver cookbook.
 
 ## Unreleased
 
+- Merge resolv.conf options & remove extra colons
+
 ## 3.0.1 - *2021-02-20*
 
 - Update `Chef` -> `Chef Infra`

--- a/spec/unit/resources/config_spec.rb
+++ b/spec/unit/resources/config_spec.rb
@@ -11,7 +11,9 @@ describe 'resolver_config' do
         domain 'test.com'
         search ['test1.com', 'test2.com']
         options(
-          'timeout' => 2
+          'timeout' => 2,
+          'rotate' => nil,
+          'attempts' => 1
         )
       end
     end
@@ -22,7 +24,7 @@ describe 'resolver_config' do
         .with_content(/nameserver 1.0.0.1/)
         .with_content(/domain test\.com/)
         .with_content(/search test1\.com test2\.com/)
-        .with_content(/options timeout:2/)
+        .with_content(/options timeout:2 rotate attempts:1/)
     end
   end
 end

--- a/templates/default/resolv.conf.erb
+++ b/templates/default/resolv.conf.erb
@@ -13,7 +13,5 @@ search <%= @search.join(' ') %>
 nameserver <%= nameserver %>
 <% end %>
 <% unless nil_or_empty?(@options) -%>
-<% @options.each do |option, value| -%>
-options <%= option %><% unless nil_or_empty?(@search) %>:<%= value %><% end %>
-<% end -%>
+options<% @options.each do |option, value| -%> <%= option %><% unless nil_or_empty?(value) %>:<%= value %><% end %><% end -%>
 <% end -%>

--- a/test/integration/cookbooks/resolver-test/recipes/default.rb
+++ b/test/integration/cookbooks/resolver-test/recipes/default.rb
@@ -3,7 +3,9 @@ resolver_config '/etc/resolv.conf' do
   domain 'test.com'
   search ['test1.com', 'test2.com']
   options(
-    'timeout' => 2
+    'timeout' => 2,
+    'rotate' => nil,
+    'attempts' => 1
   )
   override_system_configuration true
 end

--- a/test/integration/default/config_spec.rb
+++ b/test/integration/default/config_spec.rb
@@ -5,7 +5,7 @@ describe file('/etc/resolv.conf') do
   its('content') { should match /nameserver 1.0.0.1/ }
   its('content') { should match /domain test\.com/ }
   its('content') { should match /search test1\.com test2\.com/ }
-  its('content') { should match /options timeout:2/ }
+  its('content') { should match /options timeout:2 rotate attempts:1/ }
 end
 
 describe command('curl https://www.google.com') do


### PR DESCRIPTION
# Description

- Removes extra colon suffixes from the resolv.conf options line e.g `rotate:` is now `rotate`
- Merges resolv.conf options to a single line to reflect the man page syntax, ref:
```
       options
              Options allows certain internal resolver variables to be modified.  The syntax is
                     options option ...
```
## Issues Resolved

https://github.com/sous-chefs/resolver/issues/49

## Check List

- [X] All tests pass. See TESTING.md for details.
- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
