### PR TITLE
fix blog link for wrapper cookbooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the resolver cookbook.
 
 ## Unreleased
 
+- Fix blog link for wrapper cookbooks
+
 ## 3.0.2 - *2021-02-25*
 
 - Merge resolv.conf options & remove extra colons

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ## Usage
 
-It is recommended to create a project or organization specific [wrapper cookbook](https://www.chef.io/blog/2013/12/03/doing-wrapper-cookbooks-right/) and add the desired custom resources to the run list of a node.
+It is recommended to create a project or organization specific [wrapper cookbook](https://blog.chef.io/doing-wrapper-cookbooks-right) and add the desired custom resources to the run list of a node.
 
 Example of configuring a node with nameservers, a search list and a local domain.
 


### PR DESCRIPTION
there is a broken link/rewrite which results in this (note the "blog.chef.io2013/....").  The link appears ok, but when it is clicked, it is broken, and ends up as shown below:
This patch fixes the broken link.

This link:
https://www.chef.io/blog/2013/12/03/doing-wrapper-cookbooks-right/

gets redirected here (which obviously does not work)
https://blog.chef.io2013/12/03/doing-wrapper-cookbooks-right/

changing the link to this would also fix it:
https://blog.chef.io/2013/12/03/doing-wrapper-cookbooks-right/

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
