### PR TITLE
fix typo in CacheFromLocalhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the resolver cookbook.
 
 ## Unreleased
 
+- Fixed typo in the `CacheFromLocalhost` parameter in the systemd-resolved template
+
 ## 3.0.3 - *2021-02-25*
 
 - Fix blog link for wrapper cookbooks

--- a/spec/unit/resources/systemd_resolved_config_spec.rb
+++ b/spec/unit/resources/systemd_resolved_config_spec.rb
@@ -19,7 +19,7 @@ describe 'resolver_systemd_resolved_config' do
         .with_content(/FallBackDNS=8.8.8.8 8.8.4.4 2001:4860:4860::8888 2001:4860:4860::8844/)
         .with_content(/DNSSEC=allow-downgrade/)
         .with_content(/Domains=localtest.com/)
-        .with_content(/CacheFromLocahost=no/)
+        .with_content(/CacheFromLocalhost=no/)
     end
   end
 end

--- a/templates/default/resolved.conf.erb
+++ b/templates/default/resolved.conf.erb
@@ -29,7 +29,7 @@ DNSOverTLS=<%= systemd_value(@dnsovertls) %>
 Cache=<%= systemd_value(@cache) %>
 <% end -%>
 <% unless nil_or_empty?(@cachefromlocalhost) -%>
-CacheFromLocahost=<%= systemd_value(@cachefromlocalhost)%>
+CacheFromLocalhost=<%= systemd_value(@cachefromlocalhost)%>
 <% end -%>
 <% unless nil_or_empty?(@dnsstublistener) -%>
 DNSStubListener=<%= systemd_value(@dnsstublistener) %>

--- a/test/integration/systemd_resolved/systemd_resolved_spec.rb
+++ b/test/integration/systemd_resolved/systemd_resolved_spec.rb
@@ -3,7 +3,7 @@ describe file('/etc/systemd/resolved.conf') do
   its('content') { should match /FallBackDNS=8.8.8.8 8.8.4.4 2001:4860:4860::8888 2001:4860:4860::8844/ }
   its('content') { should match /DNSSEC=allow-downgrade/ }
   its('content') { should match /Domains=localtest.com/ }
-  its('content') { should match /CacheFromLocahost=no/ }
+  its('content') { should match /CacheFromLocalhost=no/ }
 end
 
 describe command('curl https://www.google.com') do


### PR DESCRIPTION
# Description

It fixes a typo in the CacheFromLocalhost attribute in the systemd-resolved template

## Issues Resolved

-

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] ~~New functionality includes testing.~~
- [ ] ~~New functionality has been documented in the README if applicable.~~
