### PR TITLE
feat(atomic_update): Allow the atomic_update property

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,34 +8,11 @@ name: ci
       - main
 
 jobs:
-  delivery:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@main
-        env:
-          CHEF_LICENSE: accept-no-persist
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run yaml Lint
-        uses: actionshub/yamllint@main
-
-  mdl:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Run Markdown Lint
-        uses: actionshub/markdownlint@main
+  lint-unit:
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
 
   integration:
-    needs: [mdl, yamllint, delivery]
+    needs: [lint-unit]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -81,7 +58,7 @@ jobs:
             KITCHEN_LOCAL_YAML=kitchen.dokken.yml /usr/bin/kitchen exec ${{ matrix.suite }}-${{ matrix.os }} -c "journalctl -l"
 
   integration-macos:
-    needs: [mdl, yamllint, delivery]
+    needs: [lint-unit]
     runs-on: macos-latest
     strategy:
       matrix:
@@ -106,7 +83,7 @@ jobs:
           os: ${{ matrix.os }}
 
   integration-freebsd:
-    needs: [mdl, yamllint, delivery]
+    needs: [lint-unit]
     runs-on: macos-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,20 +12,23 @@ jobs:
     uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
 
   integration:
-    needs: [lint-unit]
+    needs: lint-unit
     runs-on: ubuntu-latest
     strategy:
       matrix:
         os:
+          - 'almalinux-8'
           - 'amazonlinux-2'
-          - 'debian-9'
-          - 'debian-10'
           - 'centos-7'
-          - 'centos-8'
+          - 'centos-stream-8'
+          - 'debian-10'
+          - 'debian-11'
           - 'fedora-latest'
+          - 'opensuse-leap-15'
+          - 'rockylinux-8'
           - 'ubuntu-1804'
           - 'ubuntu-2004'
-          - 'opensuse-leap-15'
+          - 'ubuntu-2204'
         suite:
           - 'default'
         include:
@@ -35,6 +38,8 @@ jobs:
             os: 'ubuntu-1804'
           - suite: 'systemd-resolved'
             os: 'ubuntu-2004'
+          - suite: 'systemd-resolved'
+            os: 'ubuntu-2204'
       fail-fast: false
 
     steps:
@@ -58,7 +63,7 @@ jobs:
             KITCHEN_LOCAL_YAML=kitchen.dokken.yml /usr/bin/kitchen exec ${{ matrix.suite }}-${{ matrix.os }} -c "journalctl -l"
 
   integration-macos:
-    needs: [lint-unit]
+    needs: lint-unit
     runs-on: macos-latest
     strategy:
       matrix:
@@ -83,13 +88,13 @@ jobs:
           os: ${{ matrix.os }}
 
   integration-freebsd:
-    needs: [lint-unit]
-    runs-on: macos-latest
+    needs: lint-unit
+    runs-on: macos-10.15
     strategy:
       matrix:
         os:
-          - 'freebsd-11'
           - 'freebsd-12'
+          - 'freebsd-13'
         suite:
           - 'default'
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the resolver cookbook.
 ## Unreleased
 
 - Remove delivery and move to calling RSpec directly via a reusable workflow
+- Add the 'atomic_update' property
 
 ## 4.0.3 - *2022-02-08*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the resolver cookbook.
 
 ## Unreleased
 
+- Remove delivery and move to calling RSpec directly via a reusable workflow
+
 ## 4.0.3 - *2022-02-08*
 
 - Remove delivery folder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ This file is used to list changes made in each version of the resolver cookbook.
 ## Unreleased
 
 - Remove delivery and move to calling RSpec directly via a reusable workflow
-- Add the 'atomic_update' property
+- Add the `atomic_update` property
+- Use MacOS 10.15 when using Vagrant testing
+- Update Linux platforms for testing
 
 ## 4.0.3 - *2022-02-08*
 

--- a/documentation/resolver_config.md
+++ b/documentation/resolver_config.md
@@ -10,19 +10,20 @@ Introduced: v3.0.0
 
 ## Properties
 
-| Name                   | Type          | Default                          | Description                                                         |
-| ---------------------- | ------------- | -------------------------------- | ------------------------------------------------------------------- |
-| `config_file`          | String        | `/etc/resolv.conf`               | The path to the resolver configuration file on disk                 |
-| `cookbook`             | String        | `resolver`                       | Cookbook to source configuration file template from                 |
-| `template`             | String        | `resolv.conf.erb`                | Template to use to generate the configuration file                  |
-| `owner`                | String        | Platform dependant               | Owner of the generated configuration file                           |
-| `group`                | String        | Platform dependant               | Group of the generated configuration file                           |
-| `mode`                 | String        | `'0644'`                         | Filemode of the generated configuration file                        |
-| `nameservers`          | String, Array | `nil`                            | The DNS servers to configure for system name resolution             |
-| `domain`               | String        | `nil`                            | The DNS domain name for the host                                    |
-| `search`               | String, Array | `nil`                            | The DNS domain search list for the host                             |
-| `sortlist`             | String, Array | `nil`                            | The DNS sort list for the host                                      |
-| `options`              | Hash          | `nil`                            | Additional options to add to the resolver configuration file        |
+| Name                   | Type          | Default                          | Description                                                                     |
+| ---------------------- | ------------- | -------------------------------- | --------------------------------------------------------------------------------|
+| `config_file`          | String        | `/etc/resolv.conf`               | The path to the resolver configuration file on disk                             |
+| `cookbook`             | String        | `resolver`                       | Cookbook to source configuration file template from                             |
+| `template`             | String        | `resolv.conf.erb`                | Template to use to generate the configuration file                              |
+| `owner`                | String        | Platform dependant               | Owner of the generated configuration file                                       |
+| `group`                | String        | Platform dependant               | Group of the generated configuration file                                       |
+| `mode`                 | String        | `'0644'`                         | Filemode of the generated configuration file                                    |
+| `nameservers`          | String, Array | `nil`                            | The DNS servers to configure for system name resolution                         |
+| `domain`               | String        | `nil`                            | The DNS domain name for the host                                                |
+| `search`               | String, Array | `nil`                            | The DNS domain search list for the host                                         |
+| `sortlist`             | String, Array | `nil`                            | The DNS sort list for the host                                                  |
+| `options`              | Hash          | `nil`                            | Additional options to add to the resolver configuration file                    |
+| `atomic_update`        | true, false   | `true`                           | Allow to Ran atomic file update (Could be used when updating inside a container |
 
 ## Examples
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -16,33 +16,34 @@ verifier:
   name: inspec
 
 platforms:
+  - name: almalinux-8
+    driver:
+      image: dokken/almalinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: amazonlinux-2
     driver:
       image: dokken/amazonlinux-2
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-9
-    driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-
   - name: debian-10
     driver:
       image: dokken/debian-10
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
+      pid_one_command: /bin/systemd
 
   - name: centos-7
     driver:
       image: dokken/centos-7
       pid_one_command: /sbin/init
 
-  - name: centos-8
+  - name: centos-stream-8
     driver:
-      image: dokken/centos-8
+      image: dokken/centos-stream-8
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: fedora-latest
@@ -50,21 +51,27 @@ platforms:
       image: dokken/fedora-latest
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-16.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
 
   - name: ubuntu-20.04
     driver:
-      image: dokken/ubuntu-18.04
+      image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
+
+  - name: ubuntu-22.04
+    driver:
+      image: dokken/ubuntu-22.04
+      pid_one_command: /bin/systemd
 
   - name: opensuse-leap-15
     driver:
       image: dokken/opensuse-leap-15
-      pid_one_command: /bin/systemd
+      pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -16,8 +16,8 @@ platforms:
   - name: debian-10
   - name: debian-9
   - name: fedora-latest
-  - name: freebsd-11
-  - name: freebsd-12.2  # freebsd-12 bento box is out of sync with the ports tree
+  - name: freebsd-12
+  - name: freebsd-13
   - name: ubuntu-18.04
   - name: ubuntu-20.04
 
@@ -34,6 +34,7 @@ suites:
       - fedora-latest
       - ubuntu-18.04
       - ubuntu-20.04
+      - ubuntu-22.04
     verifier:
       inspec_tests:
         - test/integration/systemd_resolved

--- a/resources/config.rb
+++ b/resources/config.rb
@@ -70,6 +70,10 @@ property :sortlist, [String, Array],
 property :options, Hash,
           description: 'Additional options to add to the resolver configuration file'
 
+property :atomic_update, [true, false],
+          default: true,
+          description: 'Perform atomic file updates on a per-resource basis'
+
 property :override_system_configuration, [true, false],
           default: lazy { resolver_override_default(config_file) },
           description: 'Override the system DNS configuration, for use with NetworkManager/resolvconf/systemd-resolved'
@@ -102,6 +106,8 @@ action :set do
 
     force_unlink new_resource.override_system_configuration
     manage_symlink_source !new_resource.override_system_configuration
+
+    atomic_update new_resource.atomic_update
 
     variables(
       nameservers: new_resource.nameservers,

--- a/test/integration/cookbooks/resolver-test/recipes/default.rb
+++ b/test/integration/cookbooks/resolver-test/recipes/default.rb
@@ -8,4 +8,5 @@ resolver_config '/etc/resolv.conf' do
     'attempts' => 1
   )
   override_system_configuration true
+  atomic_update false
 end


### PR DESCRIPTION
STATE:
When trying to setup '/etc/resolv.conf' for a docker image, chef fails
with the following error:
>> ================================================================================
>> Error executing action `create` on resource 'template[/etc/resolv.conf]'
>> ================================================================================
>>
>> Errno::EBUSY
>> ------------
>> Device or resource busy @ rb_file_s_rename - (/etc/.chef-resolv20220527-680-734sd3.conf, /etc/resolv.conf)
>>
>> Cookbook Trace: (most recent call first)
>> ----------------------------------------
>> /opt/kitchen/cache/cookbooks/resolver/resources/config.rb:99:in `block in class_from_file'

The logic behind this error is describe on the follwing issue:
https://github.com/moby/moby/issues/9295#issuecomment-140350434
And a PR was created to fix this in a previous recipe:
https://github.com/sous-chefs/resolver/pull/22

PROPOSED SOLUTION:
Add the 'atomic_update' property on the resource

Signed-off-by: Jeremy MAURO <jeremy.mauro@gmail.com>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
